### PR TITLE
Updated Readme and setup.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Approval\_frame is a replacement for those polls, using approval voting,
 which is suitable for embedding in other webpages via an iframe tag.
 The project, taken as a whole, will serve these approval-based webpolls, or the approval\_polls package contained within it can be added to other Django-based servers to be used locally.
 
+For an example of this code in action, see [this page](https://vote.electionscience.org/approval_polls/) from the Center for Election Science website.
+
 Dependencies
 ------------
 **Option 1** : Manually install the following
@@ -28,7 +30,7 @@ Dependencies
 To learn more about why virtualenv and pip should be used, refer - [A non-magical introduction to Pip and Virtualenv for Python beginners](http://www.dabapps.com/blog/introduction-to-pip-and-virtualenv-python/)
 
 1. Install Python 2.7 from the link in step 1 above.
-2. Install [pip](https://pip.pypa.io/en/latest/installing.html) globally `sudo apt-get install python-pip`.
+2. Install [pip](https://pip.pypa.io/en/latest/installing.html) globally.
 3. Install [virtualenv](https://virtualenv.pypa.io/en/latest/) globally `sudo pip install virtualenv`.
 4. Enter the directory that contains this readme file.
 5. Create a new virtual environment `virtualenv env`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
-exclude = approval_frame/*settings.py, approval_frame/secret_key.py
+exclude = approval_frame/*settings.py, approval_frame/secret_key.py, env/**
 ignore = E123, E128, E402, W503, E731, W601, W605
 max-line-length = 119


### PR DESCRIPTION
Resolves #112 by linking [here](https://vote.electionscience.org/approval_polls/) on the readme.
Resolves #178 by removing shell command for installing pip globally. The link on pip already contains instructions for doing so anyway, and as mentioned in the issue the current method for installing pip is now somewhat more involved and won't fit neatly on one line.

When following the readme instructions on setting up the virtual environment and running flake8, I was given linting errors for all the dependencies inside the env/ folder. I updated setup.cfg to ignore all files within env/, which removed those errors and sped up the check.