### PR TITLE
Enable tags functionality and fix tag display

### DIFF
--- a/approval_polls/templates/create.html
+++ b/approval_polls/templates/create.html
@@ -117,11 +117,15 @@
                             <label class="form-check-label" for="showEmailOptIn">Display option to opt-in for email communication</label>
                         </div>
                     </div>
-                    {% comment %} <h3 class="h6 mb-3">Tags</h3>
+                    <h3 class="h6 mb-3">Tags</h3>
                     <div class="mb-3">
                         <label for="tokenTagField" class="form-label">Enter keywords (comma-separated):</label>
-                        <input type="text" class="form-control" id="tokenTagField" name="token-tags" placeholder="Enter keywords">
-                    </div> {% endcomment %}
+                        <input type="text"
+                               class="form-control"
+                               id="tokenTagField"
+                               name="token-tags"
+                               placeholder="Enter keywords">
+                    </div>
                 </div>
             </div>
             <div class="text-end">

--- a/approval_polls/templates/index.html
+++ b/approval_polls/templates/index.html
@@ -4,7 +4,7 @@
         {% if latest_poll_list %}
             <h1 class="mb-4">
                 {% if tag %}
-                    Tag: {{ tag.tag_text }}
+                    Tag: {{ tag }}
                 {% else %}
                     Latest Public Elections
                 {% endif %}

--- a/approval_polls/templates/tag_cloud.html
+++ b/approval_polls/templates/tag_cloud.html
@@ -19,7 +19,7 @@
     <script text="text/javascript">
 var words = []
 {% for k, v in topTags.items %}
-  words.push({text: '{{ k }}', weight: {{ v }}, link: '/approval_polls/tag/{{k}}'})
+  words.push({text: "{{ k|escapejs }}", weight: {{ v }}, link: "{% url 'tagged_polls' k %}"})
 {% endfor %}
 // Ensure jQuery is loaded before using it
 if (typeof jQuery !== 'undefined' && typeof jQuery.fn.jQCloud !== 'undefined') {

--- a/approval_polls/tests.py
+++ b/approval_polls/tests.py
@@ -628,11 +628,15 @@ class TagCloudTests(TestCase):
         self.assertContains(response, "new york")
 
     def test_poll_tags_index(self):
-        # print [pt.tag_text for pt in self.poll.polltag_set.all()]
         response = self.client.get(reverse("tagged_polls", args=("New York",)))
         self.assertEqual(response.status_code, 200)
-        print(response.content)
+        self.assertContains(response, "Tag: new york")
         self.assertContains(response, '<a href="/1/">Create Sample Poll.</a>')
+
+    def test_tag_cloud_links_use_tag_route(self):
+        response = self.client.get(reverse("tag_cloud"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, reverse("tagged_polls", args=("new york",)))
 
     def test_poll_delete(self):
         self.poll.polltag_set.clear()


### PR DESCRIPTION
## Summary by Sourcery

Enable poll tag input on the create form and ensure tags are displayed and linked consistently across the UI.

New Features:
- Expose the tags input section on the poll creation page so users can add comma-separated keywords to polls.

Bug Fixes:
- Fix tag display on the index page to show the raw tag value instead of tag_text.
- Update the tag cloud to generate links using the tagged_polls URL route and properly escape tag text for JavaScript.

Tests:
- Extend tag-related tests to verify tag label rendering on the index page and correct tag cloud link generation.